### PR TITLE
Allow multiple IP for SSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Include this repository as a module in your existing terraform code:
 module "auto-bastion" {
   source            = "JamesWoolfenden/auto-bastion/aws"
   version           = "0.0.4"
-  allowed_ips       = [chomp(data.http.myip.body)]
+  allowed_ips       = ["${chomp(data.http.myip.body)}/32"]
   common_tags       = var.common_tags
   vpc_id            = element(data.aws_vpcs.vpc.ids, 0)
   instance_type     = var.instance_type

--- a/aws_security_group.instance_ssh_access.tf
+++ b/aws_security_group.instance_ssh_access.tf
@@ -8,7 +8,7 @@ resource "aws_security_group" "instance_ssh_access" {
     to_port     = 22
     protocol    = "TCP"
     self        = true
-    cidr_blocks = ["${var.allowed_ips}/32"]
+    cidr_blocks = var.allowed_ips
   }
 
   egress {

--- a/example/examplea/module.bastion.tf
+++ b/example/examplea/module.bastion.tf
@@ -1,6 +1,6 @@
 module "bastion" {
   source        = "../../"
-  allowed_ips   = chomp(data.http.myip.body)
+  allowed_ips   = ["${chomp(data.http.myip.body)}/32"]
   common_tags   = var.common_tags
   vpc_id        = element(tolist(data.aws_vpcs.vpc.ids), 0)
   instance_type = var.instance_type

--- a/variables.tf
+++ b/variables.tf
@@ -21,8 +21,8 @@ variable "subnet_ids" {
 }
 
 variable "allowed_ips" {
-  description = "Allow this IP through the firewall"
-  type        = string
+  description = "Allow this list of IPs through the firewall"
+  type        = list
 }
 
 variable "common_tags" {


### PR DESCRIPTION
This PR is changing the `allowed_ips` variable to be a list which will allow to open the SSH for multiple IPs (e.g. `["1.2.3.4/32", "5.6.7.8/32"]`) or even for multiple IP ranges (e.g. `["1.2.0.0/16", "3.4.5.0/24"]`).